### PR TITLE
chore: update dependencies in go.mod and remove unused indirect packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,8 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: latest
+          skip-cache: false   # Ensure caching is enabled
+          args: --timeout=5m 
 
       # Run golangci-lint
       - name: Run Linter

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 'latest'  # Use the latest Go version
+          go-version: '1.23.5'  # Use Go version 1.23.5
 
       # Cache dependencies to speed up builds
       - name: Cache Go modules

--- a/go.mod
+++ b/go.mod
@@ -7,15 +7,11 @@ go 1.23
 require (
 	github.com/joho/godotenv v1.5.1
 	github.com/lib/pq v1.10.9
+	go.uber.org/zap v1.27.0
+	golang.org/x/oauth2 v0.23.0
 )
 
 require (
 	cloud.google.com/go/compute/metadata v0.3.0 // indirect
-	github.com/golang-jwt/jwt/v5 v5.2.1 // indirect
-	github.com/golang/protobuf v1.5.3 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	go.uber.org/zap v1.27.0 // indirect
-	golang.org/x/oauth2 v0.23.0 // indirect
-	google.golang.org/appengine v1.6.8 // indirect
-	google.golang.org/protobuf v1.32.0 // indirect
 )


### PR DESCRIPTION
This pull request includes updates to the Go version used in the CI workflow, ensures caching is enabled for `golangci-lint`, and modifies dependencies in the `go.mod` file.

Updates to CI workflow:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL23-R23): Updated the Go version to 1.23.5 for consistency and stability.
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR45-R46): Enabled caching and set a timeout for `golangci-lint` to improve build performance.

Dependency modifications:

* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R10-L20): Added `go.uber.org/zap` and `golang.org/x/oauth2` as direct dependencies.
* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R10-L20): Removed several indirect dependencies to clean up the dependency list.