### PR TITLE
feat: change Load field type to float64 in UserExerciseInput

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,11 @@ migrate-up-to:
 migrate-down-to:
 	goose -dir internal/database/migrations postgres "$(DB_URL)" down-to $(VERSION)
 
+# Create a new migration file with a specific name
+create-migration:
+	@read -p "Enter migration name: " NAME; \
+	goose -dir internal/database/migrations create $$NAME sql
+
 # Lint code
 lint:
 	golangci-lint run

--- a/internal/controllers/exercise_controller.go
+++ b/internal/controllers/exercise_controller.go
@@ -419,7 +419,7 @@ func SubmitUserExerciseDetails(w http.ResponseWriter, r *http.Request) {
 
 		if exercise.Reps <= 0 || exercise.Load <= 0 {
 			invalidExercises = append(invalidExercises,
-				fmt.Sprintf("Exercise ID %d: Reps=%d, Load=%d",
+				fmt.Sprintf("Exercise ID %d: Reps=%d, Load=%.2f",
 					exercise.ExerciseID, exercise.Reps, exercise.Load))
 			continue
 		}
@@ -428,7 +428,7 @@ func SubmitUserExerciseDetails(w http.ResponseWriter, r *http.Request) {
 			zap.Int("user_workout_id", userWorkoutID),
 			zap.Int("exercise_id", exercise.ExerciseID),
 			zap.Int("reps", exercise.Reps),
-			zap.Int("load", exercise.Load),
+			zap.Float64("load", exercise.Load),
 		)
 		// use placeholders batch insert with timestamp
 		placeholders = append(placeholders, fmt.Sprintf("($%d, $%d, $%d, $%d, $%d)", i*5+1, i*5+2, i*5+3, i*5+4, i*5+5))
@@ -523,9 +523,9 @@ func GetUserProgress(w http.ResponseWriter, r *http.Request) {
 
 	var progressData []models.UserProgressResponse
 	for rows.Next() {
-		var exerciseID int
+		var exerciseID, customReps int
 		var exerciseName string
-		var customLoad, customReps int
+		var customLoad float64
 		var submittedAt time.Time
 
 		if err := rows.Scan(&exerciseID, &exerciseName, &customLoad, &customReps, &submittedAt); err != nil {

--- a/internal/database/migrations/20250216154737_update_int_to_float.sql
+++ b/internal/database/migrations/20250216154737_update_int_to_float.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE ExerciseDetails ALTER COLUMN load TYPE DOUBLE PRECISION USING load::double precision;
+ALTER TABLE UserExercisesDetails ALTER COLUMN custom_load TYPE DOUBLE PRECISION USING custom_load::double precision;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE ExerciseDetails ALTER COLUMN load TYPE INTEGER;
+ALTER TABLE UserExercisesDetails ALTER COLUMN custom_load TYPE INTEGER;
+-- +goose StatementEnd

--- a/pkg/models/user_exercise.go
+++ b/pkg/models/user_exercise.go
@@ -8,7 +8,7 @@ import (
 type UserExerciseInput struct {
 	ExerciseID  int       `json:"exercise_id"`
 	Reps        int       `json:"custom_reps"`
-	Load        int       `json:"custom_load"`
+	Load        float64   `json:"custom_load"`
 	SubmittedAt time.Time `json:"submitted_at"`
 }
 

--- a/pkg/models/user_exercise.go
+++ b/pkg/models/user_exercise.go
@@ -32,9 +32,9 @@ func (u UserExerciseInput) MarshalJSON() ([]byte, error) {
 
 // Response model for progress data
 type UserProgressResponse struct {
-	ExerciseID   int    `json:"exercise_id"`
-	ExerciseName string `json:"exercise_name"` //refactor to use UserExerciseInput model
-	CustomLoad   int    `json:"custom_load"`
-	CustomReps   int    `json:"custom_reps"`
-	SubmittedAt  string `json:"submitted_at"`
+	ExerciseID   int     `json:"exercise_id"`
+	ExerciseName string  `json:"exercise_name"` //refactor to use UserExerciseInput model
+	CustomReps   int     `json:"custom_reps"`
+	CustomLoad   float64 `json:"custom_load"`
+	SubmittedAt  string  `json:"submitted_at"`
 }


### PR DESCRIPTION
This pull request includes several changes to improve the handling of exercise load values by converting them from integers to floating-point numbers across different parts of the codebase. Additionally, a new Makefile target has been added to facilitate the creation of migration files.

Changes to exercise load handling:

* [`internal/controllers/exercise_controller.go`](diffhunk://#diff-530467b3e85c1de32541666e00d0a9da9c369989be546e6540371768b0653298L422-R422): Updated the `SubmitUserExerciseDetails` and `GetUserProgress` functions to handle `load` as a `float64` instead of an `int`. [[1]](diffhunk://#diff-530467b3e85c1de32541666e00d0a9da9c369989be546e6540371768b0653298L422-R422) [[2]](diffhunk://#diff-530467b3e85c1de32541666e00d0a9da9c369989be546e6540371768b0653298L431-R431) [[3]](diffhunk://#diff-530467b3e85c1de32541666e00d0a9da9c369989be546e6540371768b0653298L526-R528)
* [`internal/database/migrations/20250216154737_update_int_to_float.sql`](diffhunk://#diff-194a16cc96cc99bbc4d89404436e16581d670aa36c1fb02b9f3ae6b13692d9d9R1-R11): Added a migration script to alter the `load` column type from `INTEGER` to `DOUBLE PRECISION` in the `ExerciseDetails` and `UserExercisesDetails` tables.
* [`pkg/models/user_exercise.go`](diffhunk://#diff-6eb89ceeaed1d6ec4ab0df2634413b8991a1b0e546152d782478bb3556708eaeL11-R11): Updated the `UserExerciseInput` and `UserProgressResponse` models to use `float64` for the `custom_load` field. [[1]](diffhunk://#diff-6eb89ceeaed1d6ec4ab0df2634413b8991a1b0e546152d782478bb3556708eaeL11-R11) [[2]](diffhunk://#diff-6eb89ceeaed1d6ec4ab0df2634413b8991a1b0e546152d782478bb3556708eaeL37-R38)

Makefile improvements:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R35-R39): Added a new `create-migration` target to create a new migration file with a specific name.