### PR TITLE
Feat/standard api response

### DIFF
--- a/internal/controllers/exercise_controller.go
+++ b/internal/controllers/exercise_controller.go
@@ -28,7 +28,7 @@ func GetWorkoutSections(w http.ResponseWriter, r *http.Request) {
 	// check if response is in the cache
 	if cachedData, found := workoutCache.Get(cacheKey); found {
 		utils.Logger.Info("Returning cached workout sections")
-		utils.WriteJSONResponse(w, http.StatusOK, cachedData)
+		utils.WriteStandardResponse(w, http.StatusOK, "Workout sections retrieved successfully (from cache)", cachedData)
 		return
 	}
 
@@ -60,7 +60,8 @@ func GetWorkoutSections(w http.ResponseWriter, r *http.Request) {
 	// store cache for 3 hours
 	workoutCache.Set(cacheKey, workoutSections, 3*time.Hour)
 
-	utils.WriteJSONResponse(w, http.StatusOK, workoutSections)
+	// utils.WriteJSONResponse(w, http.StatusOK, workoutSections)
+	utils.WriteStandardResponse(w, http.StatusOK, "Workout sections retrieved successfully", workoutSections)
 }
 
 // Get exercises for initial load
@@ -76,7 +77,7 @@ func GetExercisesList(w http.ResponseWriter, r *http.Request) {
 	// check if response is in the cache, if no, query db
 	if cachedData, found := workoutCache.Get(cacheKey); found {
 		utils.Logger.Info("Returning cached exercise list", zap.String("sectionID", workoutSectionID))
-		utils.WriteJSONResponse(w, http.StatusOK, cachedData)
+		utils.WriteStandardResponse(w, http.StatusOK, "Exercise list retrieved successfully (from cache)", cachedData)
 		return
 	}
 
@@ -109,7 +110,7 @@ func GetExercisesList(w http.ResponseWriter, r *http.Request) {
 	// store cache for 3 hours
 	workoutCache.Set(cacheKey, exerciseList, 3*time.Hour)
 
-	utils.WriteJSONResponse(w, http.StatusOK, exerciseList)
+	utils.WriteStandardResponse(w, http.StatusOK, "Exercise list retrieved successfully", exerciseList)
 }
 
 // Get detailed exercise information
@@ -126,7 +127,7 @@ func GetExerciseDetails(w http.ResponseWriter, r *http.Request) {
 	// Check cache first
 	if cachedData, found := workoutCache.Get(cacheKey); found {
 		utils.Logger.Info("Returning cached exercise details", zap.String("workout_section_id", workoutSectionID))
-		utils.WriteJSONResponse(w, http.StatusOK, cachedData)
+		utils.WriteStandardResponse(w, http.StatusOK, "Exercise details retrieved successfully (from cache)", cachedData)
 		return
 	}
 
@@ -170,7 +171,7 @@ func GetExerciseDetails(w http.ResponseWriter, r *http.Request) {
 
 	workoutCache.Set(cacheKey, exerciseDetails, 3*time.Hour)
 
-	utils.WriteJSONResponse(w, http.StatusOK, exerciseDetails)
+	utils.WriteStandardResponse(w, http.StatusOK, "Exercise details retrieved successfully", exerciseDetails)
 }
 
 func GetWorkoutSectionsWithExercises(w http.ResponseWriter, r *http.Request) {
@@ -185,7 +186,7 @@ func GetWorkoutSectionsWithExercises(w http.ResponseWriter, r *http.Request) {
 
 	if cachedData, found := workoutCache.Get(cacheKey); found {
 		utils.Logger.Info("Returning cached workout sections with exercises", zap.String("cacheKey", cacheKey))
-		utils.WriteJSONResponse(w, http.StatusOK, cachedData)
+		utils.WriteStandardResponse(w, http.StatusOK, "Workout sections with exercises retrieved successfully (from cache)", cachedData)
 		return
 	}
 
@@ -282,7 +283,7 @@ func GetWorkoutSectionsWithExercises(w http.ResponseWriter, r *http.Request) {
 	utils.Logger.Info("Storing workout sections with exercises in cache", zap.String("cacheKey", cacheKey))
 	workoutCache.Set(cacheKey, sections, 3*time.Hour)
 
-	utils.WriteJSONResponse(w, http.StatusOK, sections)
+	utils.WriteStandardResponse(w, http.StatusOK, "Workout sections with exercises retrieved successfully", sections)
 }
 
 // Case 1: First-time submission (New row inserted)
@@ -489,11 +490,11 @@ func SubmitUserExerciseDetails(w http.ResponseWriter, r *http.Request) {
 	utils.Logger.Info("Cache invalidated", zap.String("cacheKey", "exercise_details_"+sectionIDStr))
 
 	// return success response
-	utils.WriteJSONResponse(w, http.StatusCreated, map[string]interface{}{
-		"message":            "user exercises details submitted successfully",
+	utils.WriteStandardResponse(w, http.StatusCreated, "User exercise details submitted successfully", map[string]interface{}{
 		"user_workout_id":    userWorkoutID,
 		"inserted_exercises": insertedExercises,
 	})
+
 	utils.Logger.Info("User exercise details submitted successfully", zap.Int("user_workout_id", userWorkoutID))
 }
 
@@ -544,5 +545,5 @@ func GetUserProgress(w http.ResponseWriter, r *http.Request) {
 	}
 
 	utils.Logger.Info("User progress retrieved successfully", zap.Int("user_id", userID), zap.Int("records", len(progressData)))
-	utils.WriteJSONResponse(w, http.StatusOK, progressData)
+	utils.WriteStandardResponse(w, http.StatusOK, "User progress retrieved successfully", progressData)
 }

--- a/pkg/utils/helpers.go
+++ b/pkg/utils/helpers.go
@@ -1,4 +1,3 @@
-// internal/utils/helpers.go
 package utils
 
 import (
@@ -9,6 +8,13 @@ import (
 
 	"go.uber.org/zap"
 )
+
+type APIResponse struct {
+	Status     string      `json:"status"`     // "success" | "fail" | "error"
+	StatusCode int         `json:"statusCode"` // HTTP status code
+	Message    string      `json:"message"`
+	Data       interface{} `json:"data,omitempty"`
+}
 
 func WriteJSONResponse(w http.ResponseWriter, status int, data interface{}) {
 	w.Header().Set("Content-Type", "application/json")
@@ -60,4 +66,24 @@ func GeneratePlaceholders(count int) (string, []interface{}) {
 		zap.Strings("placeholders", placeholders),
 	)
 	return strings.Join(placeholders, ","), args
+}
+
+func WriteStandardResponse(w http.ResponseWriter, statusCode int, message string, data interface{}) {
+	status := "success"
+	if statusCode >= 400 && statusCode < 500 {
+		status = "fail"
+	} else if statusCode >= 500 {
+		status = "error"
+	}
+
+	response := APIResponse{
+		Status:     status,
+		StatusCode: statusCode,
+		Message:    message,
+		Data:       data,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
+	json.NewEncoder(w).Encode(response)
 }

--- a/pkg/utils/helpers.go
+++ b/pkg/utils/helpers.go
@@ -85,5 +85,10 @@ func WriteStandardResponse(w http.ResponseWriter, statusCode int, message string
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(statusCode)
-	json.NewEncoder(w).Encode(response)
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		Logger.Error("Failed to encode JSON response",
+			zap.Error(err),
+			zap.Int("status", http.StatusInternalServerError),
+		)
+	}
 }


### PR DESCRIPTION
This pull request includes changes to improve the consistency and clarity of API responses in the `exercise_controller.go` file by replacing `WriteJSONResponse` with a new `WriteStandardResponse` function. Additionally, a new `APIResponse` struct has been introduced in `helpers.go` to standardize the response format.

Improvements to API response consistency:

* [`internal/controllers/exercise_controller.go`](diffhunk://#diff-530467b3e85c1de32541666e00d0a9da9c369989be546e6540371768b0653298L31-R31): Replaced `utils.WriteJSONResponse` with `utils.WriteStandardResponse` in multiple functions to provide more descriptive success messages and a standardized response format. [[1]](diffhunk://#diff-530467b3e85c1de32541666e00d0a9da9c369989be546e6540371768b0653298L31-R31) [[2]](diffhunk://#diff-530467b3e85c1de32541666e00d0a9da9c369989be546e6540371768b0653298L63-R64) [[3]](diffhunk://#diff-530467b3e85c1de32541666e00d0a9da9c369989be546e6540371768b0653298L79-R80) [[4]](diffhunk://#diff-530467b3e85c1de32541666e00d0a9da9c369989be546e6540371768b0653298L112-R113) [[5]](diffhunk://#diff-530467b3e85c1de32541666e00d0a9da9c369989be546e6540371768b0653298L129-R130) [[6]](diffhunk://#diff-530467b3e85c1de32541666e00d0a9da9c369989be546e6540371768b0653298L173-R174) [[7]](diffhunk://#diff-530467b3e85c1de32541666e00d0a9da9c369989be546e6540371768b0653298L188-R189) [[8]](diffhunk://#diff-530467b3e85c1de32541666e00d0a9da9c369989be546e6540371768b0653298L285-R286) [[9]](diffhunk://#diff-530467b3e85c1de32541666e00d0a9da9c369989be546e6540371768b0653298L492-R497) [[10]](diffhunk://#diff-530467b3e85c1de32541666e00d0a9da9c369989be546e6540371768b0653298L547-R548)

Introduction of standardized response format:

* [`pkg/utils/helpers.go`](diffhunk://#diff-c7b0a78900fecf82dcd97df4767e403344d64044a1be9925267e9c0fbbd7d016R12-R18): Added a new `APIResponse` struct and the `WriteStandardResponse` function to standardize API responses across the application. [[1]](diffhunk://#diff-c7b0a78900fecf82dcd97df4767e403344d64044a1be9925267e9c0fbbd7d016R12-R18) [[2]](diffhunk://#diff-c7b0a78900fecf82dcd97df4767e403344d64044a1be9925267e9c0fbbd7d016R70-R89)