### PR TITLE
Feat/require premium middleware

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,11 @@ build-prod:
 	@echo "Building production binary..."
 	GOOS=linux GOARCH=amd64 go build -o bin/$(APP_NAME) ./cmd/main.go
 
+# Create a new migration file with a specific name
+create-migration:
+	@read -p "Enter migration name: " NAME; \
+	goose -dir internal/database/migrations create $$NAME sql
+
 # Database migrations
 migrate-up:
 	goose -dir internal/database/migrations postgres "$(DB_URL)" up
@@ -31,11 +36,6 @@ migrate-up-to:
 
 migrate-down-to:
 	goose -dir internal/database/migrations postgres "$(DB_URL)" down-to $(VERSION)
-
-# Create a new migration file with a specific name
-create-migration:
-	@read -p "Enter migration name: " NAME; \
-	goose -dir internal/database/migrations create $$NAME sql
 
 # Lint code
 lint:

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ build-prod:
 
 # Create a new migration file with a specific name
 create-migration:
-	@read -p "Enter migration name: " NAME; \
+	@read -p "Enter migration name (use underscores instead of spaces, e.g., 'add_users_table'): " NAME; \
 	goose -dir internal/database/migrations create $$NAME sql
 
 # Database migrations

--- a/internal/controllers/exercise_controller.go
+++ b/internal/controllers/exercise_controller.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"sort"
 	"strconv"
 	"time"
 
@@ -12,57 +11,10 @@ import (
 
 	"github.com/haikali3/gymbara-backend/internal/database"
 	"github.com/haikali3/gymbara-backend/internal/middleware"
-	"github.com/haikali3/gymbara-backend/pkg/cache"
 	"github.com/haikali3/gymbara-backend/pkg/models"
 	"github.com/haikali3/gymbara-backend/pkg/utils"
 	"go.uber.org/zap"
 )
-
-// init cache instance
-var workoutCache = cache.WorkoutCache
-
-// Get workout sections
-func GetWorkoutSections(w http.ResponseWriter, r *http.Request) {
-	cacheKey := "workout_sections"
-
-	// check if response is in the cache
-	if cachedData, found := workoutCache.Get(cacheKey); found {
-		utils.Logger.Info("Returning cached workout sections")
-		utils.WriteStandardResponse(w, http.StatusOK, "Workout sections retrieved successfully (from cache)", cachedData)
-		return
-	}
-
-	rows, err := database.StmtGetWorkoutSections.Query()
-	if err != nil {
-		utils.HandleError(w, "Unable to query workout sections", http.StatusInternalServerError, err)
-		return
-	}
-	defer func() {
-		if err := rows.Close(); err != nil {
-			utils.Logger.Error("Failed to close rows", zap.Error(err))
-		}
-	}()
-
-	var workoutSections []models.WorkoutSection
-	for rows.Next() {
-		var workoutSection models.WorkoutSection
-		if err := rows.Scan(&workoutSection.ID, &workoutSection.Name, &workoutSection.Route); err != nil {
-			utils.HandleError(w, "Unable to scan workout sections", http.StatusInternalServerError, err)
-			return
-		}
-		workoutSections = append(workoutSections, workoutSection)
-	}
-	if len(workoutSections) == 0 {
-		utils.HandleError(w, "No workout sections found", http.StatusNotFound, nil)
-		return
-	}
-
-	// store cache for 3 hours
-	workoutCache.Set(cacheKey, workoutSections, 3*time.Hour)
-
-	// utils.WriteJSONResponse(w, http.StatusOK, workoutSections)
-	utils.WriteStandardResponse(w, http.StatusOK, "Workout sections retrieved successfully", workoutSections)
-}
 
 // Get exercises for initial load
 func GetExercisesList(w http.ResponseWriter, r *http.Request) {
@@ -172,118 +124,6 @@ func GetExerciseDetails(w http.ResponseWriter, r *http.Request) {
 	workoutCache.Set(cacheKey, exerciseDetails, 3*time.Hour)
 
 	utils.WriteStandardResponse(w, http.StatusOK, "Exercise details retrieved successfully", exerciseDetails)
-}
-
-func GetWorkoutSectionsWithExercises(w http.ResponseWriter, r *http.Request) {
-	workoutSectionIDs := r.URL.Query()["workout_section_ids"]
-	utils.Logger.Debug("Workout section IDs received", zap.Strings("workout_section_ids", workoutSectionIDs))
-	if len(workoutSectionIDs) == 0 {
-		utils.HandleError(w, "Missing workout_section_ids parameter", http.StatusBadRequest, nil)
-		return
-	}
-
-	cacheKey := "workout_sections_with_exercises_" + strings.Join(workoutSectionIDs, "_")
-
-	if cachedData, found := workoutCache.Get(cacheKey); found {
-		utils.Logger.Info("Returning cached workout sections with exercises", zap.String("cacheKey", cacheKey))
-		utils.WriteStandardResponse(w, http.StatusOK, "Workout sections with exercises retrieved successfully (from cache)", cachedData)
-		return
-	}
-
-	placeholders, args := utils.GeneratePlaceholders(len(workoutSectionIDs))
-	for i, id := range workoutSectionIDs {
-		args[i] = id
-	}
-
-	query := fmt.Sprintf(`
-			SELECT
-				ws.id AS section_id,
-				ws.name AS section_name,
-				ws.route AS section_route,
-				e.id AS exercise_id,
-				e.name AS exercise_name
-			FROM
-				WorkoutSections ws
-			LEFT JOIN
-				Exercises e
-			ON
-				ws.id = e.workout_section_id
-			WHERE
-				ws.id IN (%s)
-			ORDER BY
-				ws.id, e.id;
-    `, placeholders)
-
-	stmt, err := database.DB.Prepare(query)
-	if err != nil {
-		utils.HandleError(w, "Unable to prepare statement for querying workout sections and exercises", http.StatusInternalServerError, err)
-		return
-	}
-	defer func() {
-		if err := stmt.Close(); err != nil {
-			utils.Logger.Error("Failed to close statement", zap.Error(err))
-		}
-	}()
-
-	rows, err := stmt.Query(args...)
-	if err != nil {
-		utils.HandleError(w, fmt.Sprintf("Unable to query workout sections and exercises for workout_section_ids: %v. Query: %s", workoutSectionIDs, query), http.StatusInternalServerError, err)
-		return
-	}
-	defer func() {
-		if err := rows.Close(); err != nil {
-			utils.Logger.Error("Failed to close rows", zap.Error(err))
-		}
-	}()
-
-	//map is unordered lol
-	sectionsMap := make(map[int]*models.WorkoutSectionWithExercises)
-	for rows.Next() {
-		var sectionID int
-		var sectionName, sectionRoute string
-		var exercise models.ExerciseMinimal
-
-		err := rows.Scan(
-			&sectionID,
-			&sectionName,
-			&sectionRoute,
-			&exercise.ID,
-			&exercise.ExerciseName,
-		)
-		if err != nil {
-			utils.HandleError(w, fmt.Sprintf("Error scanning row for section_id: %d. Partial data: SectionName=%s, Route=%s", sectionID, sectionName, sectionRoute), http.StatusInternalServerError, err)
-			return
-		}
-
-		if _, exists := sectionsMap[sectionID]; !exists {
-			sectionsMap[sectionID] = &models.WorkoutSectionWithExercises{
-				ID:        sectionID,
-				Name:      sectionName,
-				Route:     sectionRoute,
-				Exercises: []models.ExerciseMinimal{},
-			}
-		}
-
-		// Add the exercise to the section
-		if exercise.ID != 0 {
-			sectionsMap[sectionID].Exercises = append(sectionsMap[sectionID].Exercises, exercise)
-		}
-	}
-
-	sections := make([]models.WorkoutSectionWithExercises, 0, len(sectionsMap))
-	for _, section := range sectionsMap {
-		sections = append(sections, *section)
-	}
-
-	sort.Slice(sections, func(i, j int) bool {
-		return sections[i].ID < sections[j].ID
-	})
-
-	// ✅ Store in cache for 24 hours
-	utils.Logger.Info("Storing workout sections with exercises in cache", zap.String("cacheKey", cacheKey))
-	workoutCache.Set(cacheKey, sections, 3*time.Hour)
-
-	utils.WriteStandardResponse(w, http.StatusOK, "Workout sections with exercises retrieved successfully", sections)
 }
 
 // Case 1: First-time submission (New row inserted)

--- a/internal/controllers/workout_controller.go
+++ b/internal/controllers/workout_controller.go
@@ -1,0 +1,172 @@
+package controllers
+
+import (
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/haikali3/gymbara-backend/internal/database"
+	"github.com/haikali3/gymbara-backend/pkg/cache"
+	"github.com/haikali3/gymbara-backend/pkg/models"
+	"github.com/haikali3/gymbara-backend/pkg/utils"
+	"go.uber.org/zap"
+)
+
+// init cache instance
+var workoutCache = cache.WorkoutCache
+
+func GetWorkoutSections(w http.ResponseWriter, r *http.Request) {
+	cacheKey := "workout_sections"
+
+	// check if response is in the cache
+	if cachedData, found := workoutCache.Get(cacheKey); found {
+		utils.Logger.Info("Returning cached workout sections")
+		utils.WriteStandardResponse(w, http.StatusOK, "Workout sections retrieved successfully (from cache)", cachedData)
+		return
+	}
+
+	rows, err := database.StmtGetWorkoutSections.Query()
+	if err != nil {
+		utils.HandleError(w, "Unable to query workout sections", http.StatusInternalServerError, err)
+		return
+	}
+	defer func() {
+		if err := rows.Close(); err != nil {
+			utils.Logger.Error("Failed to close rows", zap.Error(err))
+		}
+	}()
+
+	var workoutSections []models.WorkoutSection
+	for rows.Next() {
+		var workoutSection models.WorkoutSection
+		if err := rows.Scan(&workoutSection.ID, &workoutSection.Name, &workoutSection.Route); err != nil {
+			utils.HandleError(w, "Unable to scan workout sections", http.StatusInternalServerError, err)
+			return
+		}
+		workoutSections = append(workoutSections, workoutSection)
+	}
+	if len(workoutSections) == 0 {
+		utils.HandleError(w, "No workout sections found", http.StatusNotFound, nil)
+		return
+	}
+
+	// store cache for 3 hours
+	workoutCache.Set(cacheKey, workoutSections, 3*time.Hour)
+
+	// utils.WriteJSONResponse(w, http.StatusOK, workoutSections)
+	utils.WriteStandardResponse(w, http.StatusOK, "Workout sections retrieved successfully", workoutSections)
+}
+
+func GetWorkoutSectionsWithExercises(w http.ResponseWriter, r *http.Request) {
+	workoutSectionIDs := r.URL.Query()["workout_section_ids"]
+	utils.Logger.Debug("Workout section IDs received", zap.Strings("workout_section_ids", workoutSectionIDs))
+	if len(workoutSectionIDs) == 0 {
+		utils.HandleError(w, "Missing workout_section_ids parameter", http.StatusBadRequest, nil)
+		return
+	}
+
+	cacheKey := "workout_sections_with_exercises_" + strings.Join(workoutSectionIDs, "_")
+
+	if cachedData, found := workoutCache.Get(cacheKey); found {
+		utils.Logger.Info("Returning cached workout sections with exercises", zap.String("cacheKey", cacheKey))
+		utils.WriteStandardResponse(w, http.StatusOK, "Workout sections with exercises retrieved successfully (from cache)", cachedData)
+		return
+	}
+
+	placeholders, args := utils.GeneratePlaceholders(len(workoutSectionIDs))
+	for i, id := range workoutSectionIDs {
+		args[i] = id
+	}
+
+	query := fmt.Sprintf(`
+			SELECT
+				ws.id AS section_id,
+				ws.name AS section_name,
+				ws.route AS section_route,
+				e.id AS exercise_id,
+				e.name AS exercise_name
+			FROM
+				WorkoutSections ws
+			LEFT JOIN
+				Exercises e
+			ON
+				ws.id = e.workout_section_id
+			WHERE
+				ws.id IN (%s)
+			ORDER BY
+				ws.id, e.id;
+    `, placeholders)
+
+	stmt, err := database.DB.Prepare(query)
+	if err != nil {
+		utils.HandleError(w, "Unable to prepare statement for querying workout sections and exercises", http.StatusInternalServerError, err)
+		return
+	}
+	defer func() {
+		if err := stmt.Close(); err != nil {
+			utils.Logger.Error("Failed to close statement", zap.Error(err))
+		}
+	}()
+
+	rows, err := stmt.Query(args...)
+	if err != nil {
+		utils.HandleError(w, fmt.Sprintf("Unable to query workout sections and exercises for workout_section_ids: %v. Query: %s", workoutSectionIDs, query), http.StatusInternalServerError, err)
+		return
+	}
+	defer func() {
+		if err := rows.Close(); err != nil {
+			utils.Logger.Error("Failed to close rows", zap.Error(err))
+		}
+	}()
+
+	//map is unordered lol
+	sectionsMap := make(map[int]*models.WorkoutSectionWithExercises)
+	for rows.Next() {
+		var sectionID int
+		var sectionName, sectionRoute string
+		var exercise models.ExerciseMinimal
+
+		err := rows.Scan(
+			&sectionID,
+			&sectionName,
+			&sectionRoute,
+			&exercise.ID,
+			&exercise.ExerciseName,
+		)
+		if err != nil {
+			utils.HandleError(w, fmt.Sprintf("Error scanning row for section_id: %d. Partial data: SectionName=%s, Route=%s", sectionID, sectionName, sectionRoute), http.StatusInternalServerError, err)
+			return
+		}
+
+		if _, exists := sectionsMap[sectionID]; !exists {
+			sectionsMap[sectionID] = &models.WorkoutSectionWithExercises{
+				ID:        sectionID,
+				Name:      sectionName,
+				Route:     sectionRoute,
+				Exercises: []models.ExerciseMinimal{},
+			}
+		}
+
+		// Add the exercise to the section
+		if exercise.ID != 0 {
+			sectionsMap[sectionID].Exercises = append(sectionsMap[sectionID].Exercises, exercise)
+		}
+	}
+
+	sections := make([]models.WorkoutSectionWithExercises, 0, len(sectionsMap))
+	for _, section := range sectionsMap {
+		sections = append(sections, *section)
+	}
+
+	sort.Slice(sections, func(i, j int) bool {
+		return sections[i].ID < sections[j].ID
+	})
+
+	// ✅ Store in cache for 24 hours
+	utils.Logger.Info("Storing workout sections with exercises in cache", zap.String("cacheKey", cacheKey))
+	workoutCache.Set(cacheKey, sections, 3*time.Hour)
+
+	utils.WriteStandardResponse(w, http.StatusOK, "Workout sections with exercises retrieved successfully", sections)
+}

--- a/internal/database/migrations/20250402031238_remove_column_customerid_subscription.sql
+++ b/internal/database/migrations/20250402031238_remove_column_customerid_subscription.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE subscriptions DROP COLUMN stripe_customer_id;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE subscriptions ADD COLUMN stripe_customer_id VARCHAR(255);
+-- +goose StatementEnd

--- a/internal/middleware/require_premium.go
+++ b/internal/middleware/require_premium.go
@@ -1,0 +1,31 @@
+package middleware
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/haikali3/gymbara-backend/internal/database"
+	"github.com/haikali3/gymbara-backend/pkg/utils"
+)
+
+func RequirePremium(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// Corrected type assertion
+		userIDValue := r.Context().Value(UserIDKey)
+		userID, ok := userIDValue.(int)
+		if !ok {
+			utils.HandleError(w, "Invalid user ID in context", http.StatusUnauthorized, nil)
+			return
+		}
+
+		//query subs
+		var expiration time.Time
+		err := database.DB.QueryRow("SELECT expiration_date FROM subscriptions WHERE user_id = $1", userID).Scan(&expiration)
+		if err != nil || time.Now().After(expiration) {
+			utils.HandleError(w, "Access denied: Subscription required", http.StatusPaymentRequired, nil)
+			return
+		}
+
+		next(w, r)
+	}
+}


### PR DESCRIPTION
decide premium middleware should be in route level or move the premium check into the controller, and make it section-aware.

This pull request includes several changes to the `Makefile`, a new SQL migration file, and the addition of a new middleware function. The most important changes include the addition of a new `create-migration` target, the removal of an outdated `create-migration` target, the creation of a new SQL migration file, and the addition of a middleware function to require premium access.

### Changes to `Makefile`:

* Added a new `create-migration` target to create a new migration file with a specific name.
* Removed the outdated `create-migration` target from the `migrate-up-to` section.

### New SQL migration file:

* Created a new migration file `20250402031238_remove_column_customerid_subscription.sql` to handle the addition and removal of the `stripe_customer_id` column in the `subscriptions` table.

### Middleware addition:

* Added a new middleware function `RequirePremium` in `require_premium.go` to check if a user has a valid subscription before allowing access to premium features.