### PR TITLE
feat: require premium access for workout sections routes

### DIFF
--- a/internal/middleware/authmiddleware.go
+++ b/internal/middleware/authmiddleware.go
@@ -25,7 +25,7 @@ func AuthMiddleware(next http.HandlerFunc) http.HandlerFunc {
 		accessToken, err := r.Cookie("access_token")
 		if err != nil {
 			utils.Logger.Error("Access token cookie missing", zap.Error(err))
-			http.Error(w, "Access token not found", http.StatusUnauthorized)
+			utils.WriteStandardResponse(w, http.StatusUnauthorized, "Access token not found", nil)
 			return
 		}
 
@@ -35,7 +35,7 @@ func AuthMiddleware(next http.HandlerFunc) http.HandlerFunc {
 		userID, err := auth.ValidateToken(accessToken.Value)
 		if err != nil {
 			utils.Logger.Error("Invalid access token", zap.Error(err))
-			http.Error(w, "Invalid access token", http.StatusUnauthorized)
+			utils.WriteStandardResponse(w, http.StatusUnauthorized, "Invalid access token", nil)
 			return
 		}
 
@@ -46,7 +46,7 @@ func AuthMiddleware(next http.HandlerFunc) http.HandlerFunc {
 		err = database.DB.QueryRow("SELECT email FROM Users WHERE id = $1", userID).Scan(&email)
 		if err != nil {
 			utils.Logger.Error("Failed to fetch user email from database", zap.Error(err))
-			http.Error(w, "User email not found", http.StatusUnauthorized)
+			utils.WriteStandardResponse(w, http.StatusUnauthorized, "User email not found", nil)
 			return
 		}
 

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -24,10 +24,10 @@ func RegisterRoutes() {
 	}
 
 	// Workout routes
-	http.Handle("/workout-sections", secureHandler(middleware.RequirePremium(controllers.GetWorkoutSections)))
-	http.Handle("/workout-sections/list", secureHandler(middleware.RequirePremium(controllers.GetExercisesList)))
-	http.Handle("/workout-sections/details", secureHandler(middleware.RequirePremium(controllers.GetExerciseDetails)))
-	http.Handle("/workout-sections/exercises", secureHandler(middleware.RequirePremium(controllers.GetWorkoutSectionsWithExercises)))
+	http.Handle("/workout-sections", secureHandler(middleware.RequireSubscription(controllers.GetWorkoutSections)))
+	http.Handle("/workout-sections/list", secureHandler(middleware.RequireSubscription(controllers.GetExercisesList)))
+	http.Handle("/workout-sections/details", secureHandler(middleware.RequireSubscription(controllers.GetExerciseDetails)))
+	http.Handle("/workout-sections/exercises", secureHandler(middleware.RequireSubscription(controllers.GetWorkoutSectionsWithExercises)))
 
 	// User submit exercise details
 	http.Handle("/workout-sections/user-exercise-details", secureHandler(controllers.SubmitUserExerciseDetails))

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -24,10 +24,10 @@ func RegisterRoutes() {
 	}
 
 	// Workout routes
-	http.Handle("/workout-sections", secureHandler(controllers.GetWorkoutSections))
-	http.Handle("/workout-sections/list", secureHandler(controllers.GetExercisesList))
-	http.Handle("/workout-sections/details", secureHandler(controllers.GetExerciseDetails))
-	http.Handle("/workout-sections/exercises", secureHandler(controllers.GetWorkoutSectionsWithExercises))
+	http.Handle("/workout-sections", secureHandler(middleware.RequirePremium(controllers.GetWorkoutSections)))
+	http.Handle("/workout-sections/list", secureHandler(middleware.RequirePremium(controllers.GetExercisesList)))
+	http.Handle("/workout-sections/details", secureHandler(middleware.RequirePremium(controllers.GetExerciseDetails)))
+	http.Handle("/workout-sections/exercises", secureHandler(middleware.RequirePremium(controllers.GetWorkoutSectionsWithExercises)))
 
 	// User submit exercise details
 	http.Handle("/workout-sections/user-exercise-details", secureHandler(controllers.SubmitUserExerciseDetails))


### PR DESCRIPTION
This pull request includes changes to the `internal/middleware/require_premium.go` and `internal/routes/routes.go` files to improve the handling of premium subscription requirements and to ensure that certain routes are protected by the premium middleware.

### Improvements to subscription handling:

* [`internal/middleware/require_premium.go`](diffhunk://#diff-0136d925f2cede7b472fd1f9f18f626a6f27f540a06dad889bc7685783852cafL13-R35): Updated the error handling to use `utils.WriteStandardResponse` instead of `utils.HandleError` for consistency and clarity. Enhanced the SQL query to fetch the most recent subscription expiration date and handle cases where no active subscription exists.

### Route protection:

* [`internal/routes/routes.go`](diffhunk://#diff-8916c4df6a76d9a9d01c7411922d5f980c5cbaad5848ecf18679e294645712d0L27-R30): Modified the workout-related routes to include the `RequirePremium` middleware, ensuring that these routes are accessible only to users with an active premium subscription.