### PR TITLE
feat: add seed management commands and initial exercises seed file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,23 @@ seed-down:
       -table goose_seed_version \
       postgres "$(DB_URL)" down
 
+seed-status:
+	goose -dir internal/database/seeds \
+      -table goose_seed_version \
+      postgres "$(DB_URL)" status
+
+# apply seeds up to a specific version
+seed-up-to:
+	goose -dir internal/database/seeds \
+      -table goose_seed_version \
+      postgres "$(DB_URL)" up-to $(VERSION)
+
+# roll back seeds down to a specific version
+seed-down-to:
+	goose -dir internal/database/seeds \
+      -table goose_seed_version \
+      postgres "$(DB_URL)" down-to $(VERSION)
+
 # Migrations and Seed
 migrate-and-seed: migrate-up
 	goose -dir internal/database/seeds -table goose_seed_version \

--- a/internal/database/seeds/20250426132152_init_seed.sql
+++ b/internal/database/seeds/20250426132152_init_seed.sql
@@ -14,4 +14,7 @@ INSERT INTO WorkoutSections (name, route) VALUES
 DELETE FROM WorkoutSections
   WHERE route IN ('full_body', 'upper_body', 'lower_body');
 
+-- rewind the auto-inc back to 1
+ALTER SEQUENCE workoutsections_id_seq RESTART WITH 1;
+
 -- +goose StatementEnd

--- a/internal/database/seeds/20250426232830_add_exercises_full_body.sql
+++ b/internal/database/seeds/20250426232830_add_exercises_full_body.sql
@@ -82,4 +82,7 @@ WHERE
     'Hanging Leg Raise'
   );
 
+-- rewind the auto-increment back to 1
+ALTER SEQUENCE exercises_id_seq RESTART WITH 1;
+
 -- +goose StatementEnd

--- a/internal/database/seeds/20250426232830_add_exercises_full_body.sql
+++ b/internal/database/seeds/20250426232830_add_exercises_full_body.sql
@@ -1,0 +1,85 @@
+-- +goose Up
+-- +goose StatementBegin
+INSERT INTO
+  Exercises (
+    name,
+    workoutsection_id,
+    notes,
+    substitution_1,
+    substitution_2
+  )
+VALUES
+  (
+    'Incline Machine Press',
+    1,
+    '45° incline, focus on squeezing your chest.',
+    'Incline Smith Machine Press',
+    'Incline DB Press'
+  ),
+  (
+    'Single-Leg Leg Press(Heavy)',
+    1,
+    'High and wide foot positioning, start with weaker leg.',
+    'Machine Squat',
+    'Hack Squat'
+  ),
+  (
+    'Single-Leg Leg Press(Back off)',
+    1,
+    'High and wide foot positioning, start with weaker leg.',
+    'Machine Squat',
+    'Hack Squat'
+  ),
+  (
+    'Pendlay Row',
+    1,
+    'Initiate the movement by squeezing your shoulder blades together, pull to your lower chest, avoid using momentum.',
+    'T-Bar Row',
+    'Seated Cable Row'
+  ),
+  (
+    'Glute-Ham Raise',
+    1,
+    'Keep your hips straight, do Nordic ham curls if no GHR machine.',
+    'Nordic Ham Curl',
+    'Lying Leg Curl'
+  ),
+  (
+    'Spider Curl',
+    1,
+    'Dropset: perform 12–15 reps, drop the weight by ~50%, perform an additional 12–15 reps. Brace your chest against an incline bench, curl with your elbows slightly in front of you.',
+    'DB Preacher Curl',
+    'Bayesian Cable Curl'
+  ),
+  (
+    'Cable Lateral Raise',
+    1,
+    'Dropset: perform 12–15 reps, drop the weight by ~50%, perform an additional 12–15 reps. Lean away from the cable. Focus on squeezing your delts.',
+    'Machine Lateral Raise',
+    'DB Lateral Raise'
+  ),
+  (
+    'Hanging Leg Raise',
+    1,
+    'Knees to chest, controlled reps, straighten legs more to increase difficulty.',
+    'Roman Chair Crunch',
+    'Reverse Crunch'
+  );
+
+-- +goose StatementEnd
+-- +goose Down
+-- +goose StatementBegin
+DELETE FROM Exercises
+WHERE
+  name IN (
+    'Incline Machine Press',
+    'Single-Leg Leg Press(Heavy)',
+    'Single-Leg Leg Press(Back off)',
+    'Pendlay Row',
+    'Glute-Ham Raise',
+    'Spider Curl',
+    'Cable Lateral Raise',
+    'Hanging Leg Raise'
+  );
+
+-- +goose StatementEnd

--- a/internal/database/seeds/20250427001212_add_exercise_details.sql
+++ b/internal/database/seeds/20250427001212_add_exercise_details.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- +goose StatementBegin
+SELECT 'up SQL query';
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+SELECT 'down SQL query';
+-- +goose StatementEnd


### PR DESCRIPTION
This pull request introduces new functionality for managing database seeds and adds initial seed data for exercises. The changes enhance the flexibility of seed management and expand the database with pre-defined exercise data.

### Seed Management Enhancements:
* Added new `Makefile` targets for managing seeds: `seed-status` to check the status of seeds, `seed-up-to` to apply seeds up to a specific version, and `seed-down-to` to roll back seeds down to a specific version. These changes improve the control and visibility of seed operations. (`Makefile`, [MakefileR59-R75](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R59-R75))

### Database Seed Data:
* Updated the initial seed file to reset the `workoutsections_id_seq` sequence back to 1 after deleting entries in the `WorkoutSections` table, ensuring consistent ID generation. (`internal/database/seeds/20250426132152_init_seed.sql`, [internal/database/seeds/20250426132152_init_seed.sqlR17-R19](diffhunk://#diff-84088698e29ff0eccb89fabf33c9ee950fe71c388b29c81ff86847aae18bce0aR17-R19))
* Added a new seed file to populate the `Exercises` table with predefined exercise data for the "full body" workout section. The seed includes details such as exercise names, notes, and substitution options. A corresponding rollback operation is also defined to delete the inserted data. (`internal/database/seeds/20250426232830_add_exercises_full_body.sql`, [internal/database/seeds/20250426232830_add_exercises_full_body.sqlR1-R85](diffhunk://#diff-c69d212c3bc67145bfd3c6f0e096d0a367c4477f7a712a9acb990adf2917a5f7R1-R85))