### PR TITLE
feat: add SQL seed files for exercises and exercise details; alter rp…

### DIFF
--- a/internal/database/migrations/20250427003021_alter_exercisedetails_rpe_to_varchar.sql
+++ b/internal/database/migrations/20250427003021_alter_exercisedetails_rpe_to_varchar.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE exercisedetails ALTER COLUMN rpe TYPE VARCHAR;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE exercisedetails ALTER COLUMN rpe TYPE INTEGER; -- Assuming the original type was INTEGER
+-- +goose StatementEnd

--- a/internal/database/seeds/20250426232830_add_exercises_full_body.sql
+++ b/internal/database/seeds/20250426232830_add_exercises_full_body.sql
@@ -1,3 +1,4 @@
+-- file: internal/database/seeds/20250426232830_add_exercises_full_body.sql
 -- +goose Up
 -- +goose StatementBegin
 INSERT INTO
@@ -83,6 +84,7 @@ WHERE
   );
 
 -- rewind the auto-increment back to 1
-ALTER SEQUENCE exercises_id_seq RESTART WITH 1;
+ALTER SEQUENCE exercises_id_seq
+RESTART WITH 1;
 
 -- +goose StatementEnd

--- a/internal/database/seeds/20250427001212_add_exercise_details.sql
+++ b/internal/database/seeds/20250427001212_add_exercise_details.sql
@@ -1,9 +1,33 @@
+-- file: internal/database/seeds/20250427001212_add_exercise_details.sql
+
 -- +goose Up
 -- +goose StatementBegin
-SELECT 'up SQL query';
+INSERT INTO ExerciseDetails (exercise_id, week_start, week_end, warmup_sets, working_sets, reps, load, rpe, rest_time) VALUES 
+(1, 5, 8, 1, 2, '8-10', NULL, '9-10', '~2 MINS'),
+(2, 5, 8, 2, 1, '6-8 per leg', NULL, '8-9', '~3 MINS'),
+(3, 5, 8, 0, 1, '10-12 per leg', NULL, '8-9', '~3 MINS'),
+(4, 5, 8, 2, 2, '8-10', NULL, '9-10', '~2 MINS'),
+(5, 5, 8, 1, 1, '10-12', NULL, '10', '~1.5 MINS'),
+(6, 5, 8, 1, 1, '12-15 (dropset)', NULL, '10', '~1.5 MINS'),
+(7, 5, 8, 1, 1, '12-15 (dropset)', NULL, '10', '~1.5 MINS'),
+(8, 5, 8, 0, 1, '12-15', NULL, '10', '~1.5 MINS');
 -- +goose StatementEnd
 
 -- +goose Down
 -- +goose StatementBegin
-SELECT 'down SQL query';
+DELETE FROM ExerciseDetails
+WHERE (exercise_id, week_start, week_end) IN (
+  (1, 5, 8),
+  (2, 5, 8),
+  (3, 5, 8),
+  (4, 5, 8),
+  (5, 5, 8),
+  (6, 5, 8),
+  (7, 5, 8),
+  (8, 5, 8)
+);
+
+-- Reset the ID auto-increment sequence
+ALTER SEQUENCE exercisedetails_id_seq RESTART WITH 1;
+
 -- +goose StatementEnd


### PR DESCRIPTION
…e column type to VARCHAR

This pull request includes database schema and seed data updates to enhance the handling of exercise details. The changes focus on modifying the `rpe` column type, adding new seed data for exercises, and ensuring proper sequence management for auto-increment IDs.

### Database Schema Changes:
* Updated the `rpe` column in the `exercisedetails` table to use `VARCHAR` instead of `INTEGER`, allowing for more flexible representations of RPE values. A corresponding rollback script is included to revert the type back to `INTEGER`. (`internal/database/migrations/20250427003021_alter_exercisedetails_rpe_to_varchar.sql`, [internal/database/migrations/20250427003021_alter_exercisedetails_rpe_to_varchar.sqlR1-R9](diffhunk://#diff-dc50a92f26ced4f3e1dc44ad3ad7f63928b513d8db830cddb375cb700ceff706R1-R9))

### Seed Data Additions:
* Added new seed data for the `ExerciseDetails` table, including multiple entries with details such as `reps`, `rpe`, and `rest_time`. This data supports a new set of exercises for weeks 5 to 8. (`internal/database/seeds/20250427001212_add_exercise_details.sql`, [internal/database/seeds/20250427001212_add_exercise_details.sqlR1-R32](diffhunk://#diff-5701e75f2d0aea5952d10a592aea4d8ec30649d759c9487e39dcf6ca514eeadeR1-R32))

### Sequence Management:
* Adjusted the `ALTER SEQUENCE` statement formatting in the seed file for better readability. (`internal/database/seeds/20250426232830_add_exercises_full_body.sql`, [internal/database/seeds/20250426232830_add_exercises_full_body.sqlL86-R88](diffhunk://#diff-c69d212c3bc67145bfd3c6f0e096d0a367c4477f7a712a9acb990adf2917a5f7L86-R88))
* Included a reset of the auto-increment sequence for the `exercisedetails` table in the seed file's `Down` script to maintain consistency when rolling back changes. (`internal/database/seeds/20250427001212_add_exercise_details.sql`, [internal/database/seeds/20250427001212_add_exercise_details.sqlR1-R32](diffhunk://#diff-5701e75f2d0aea5952d10a592aea4d8ec30649d759c9487e39dcf6ca514eeadeR1-R32))