### PR TITLE
Fix/add upper body exercise

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,20 @@ seed-down-to:
       -table goose_seed_version \
       postgres "$(DB_URL)" down-to $(VERSION)
 
+seed-reset:
+	@echo "🧹 wiping out data & schemas…"
+	psql postgres://postgres:postgres@localhost:5432/gymbara \
+	  -c "DELETE FROM exercisedetails; DELETE FROM exercises; DELETE FROM workoutsections;"
+	psql postgres://postgres:postgres@localhost:5432/gymbara \
+	  -c "ALTER SEQUENCE exercisedetails_id_seq RESTART WITH 1; ALTER SEQUENCE exercises_id_seq RESTART WITH 1; ALTER SEQUENCE workoutsections_id_seq RESTART WITH 1;"
+	psql postgres://postgres:postgres@localhost:5432/gymbara \
+	  -c "TRUNCATE TABLE goose_seed_version;"
+	@echo "🚀 re-seeding from zero…"
+	goose -dir internal/database/seeds \
+	  -table goose_seed_version \
+	  postgres "postgres://postgres:postgres@localhost:5432/gymbara?sslmode=disable" up
+
+
 # Migrations and Seed
 migrate-and-seed: migrate-up
 	goose -dir internal/database/seeds -table goose_seed_version \

--- a/internal/database/seeds/20250426132152_init_seed.sql
+++ b/internal/database/seeds/20250426132152_init_seed.sql
@@ -1,3 +1,5 @@
+-- file: internal/database/seeds/20250426132152_init_seed.sql
+
 -- +goose Up
 -- +goose StatementBegin
 

--- a/internal/database/seeds/20250426132152_init_seed.sql
+++ b/internal/database/seeds/20250426132152_init_seed.sql
@@ -16,7 +16,4 @@ INSERT INTO WorkoutSections (name, route) VALUES
 DELETE FROM WorkoutSections
   WHERE route IN ('full_body', 'upper_body', 'lower_body');
 
--- rewind the auto-inc back to 1
-ALTER SEQUENCE workoutsections_id_seq RESTART WITH 1;
-
 -- +goose StatementEnd

--- a/internal/database/seeds/20250426232830_add_exercises_full_body.sql
+++ b/internal/database/seeds/20250426232830_add_exercises_full_body.sql
@@ -83,8 +83,4 @@ WHERE
     'Hanging Leg Raise'
   );
 
--- rewind the auto-increment back to 1
-ALTER SEQUENCE exercises_id_seq
-RESTART WITH 1;
-
 -- +goose StatementEnd

--- a/internal/database/seeds/20250427001212_add_exercise_details.sql
+++ b/internal/database/seeds/20250427001212_add_exercise_details.sql
@@ -26,7 +26,4 @@ WHERE (exercise_id, week_start, week_end) IN (
   (8, 5, 8)
 );
 
--- Reset the ID auto-increment sequence
-ALTER SEQUENCE exercisedetails_id_seq RESTART WITH 1;
-
 -- +goose StatementEnd

--- a/internal/database/seeds/20250427001212_add_exercise_details.sql
+++ b/internal/database/seeds/20250427001212_add_exercise_details.sql
@@ -1,5 +1,4 @@
 -- file: internal/database/seeds/20250427001212_add_exercise_details.sql
-
 -- +goose Up
 -- +goose StatementBegin
 INSERT INTO ExerciseDetails (exercise_id, week_start, week_end, warmup_sets, working_sets, reps, load, rpe, rest_time) VALUES 

--- a/internal/database/seeds/20250427022315_add_upper_body_exercise.sql
+++ b/internal/database/seeds/20250427022315_add_upper_body_exercise.sql
@@ -1,0 +1,33 @@
+
+-- +goose Up
+-- +goose StatementBegin
+
+-- Insert Exercises (Upper Body)
+INSERT INTO Exercises (name, workoutsection_id, notes, substitution_1, substitution_2) VALUES
+('2-Grip Pullup', 2, 'First set 1.5x shoulder width grip. Second set 1.0x shoulder width grip.', 'Machine Pulldown', '2-Grip Lat Pulldown'),
+('Weighted Dip(Heavy)', 2, 'Tuck your elbows at 45°, lean your torso forward 15°, shoulder width or slightly wider grip.', 'Machine Chest Press', 'Flat DB Press'),
+('Weighted Dip(Back off)', 2, 'Tuck your elbows at 45°, lean your torso forward 15°, shoulder width or slightly wider grip.', 'Machine Chest Press', 'Flat DB Press'),
+('Incline Chest-Supported DB Row', 2, 'Keep elbows at ~30° angle from torso. Pull the weight towards your navel.', 'Chest-Supported T-Bar Row', 'Seated Cable Row'),
+('Standing DB Arnold Press', 2, 'Start with your elbows in front of you and palms facing in. Rotate the dumbbells so that your palms face forward as you press.', 'Machine Shoulder Press', 'Seated DB Shoulder Press'),
+('A1: DB Incline Curl', 2, 'Brace upper back against bench 45° incline, keep shoulder back as you curl.', 'Cable EZ Curl', 'EZ Bar Curl'),
+('A2: DB French Press', 2, 'Can perform seated or standing. Press the dumbbell straight up and down behind your head.', 'Overhead Cable Triceps Extension', 'EZ Bar Skull Crusher');
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+-- Delete Upper Body Exercises
+DELETE FROM Exercises
+WHERE name IN (
+  '2-Grip Pullup',
+  'Weighted Dip(Heavy)',
+  'Weighted Dip(Back off)',
+  'Incline Chest-Supported DB Row',
+  'Standing DB Arnold Press',
+  'A1: DB Incline Curl',
+  'A2: DB French Press'
+);
+
+
+-- +goose StatementEnd

--- a/internal/database/seeds/20250427022534_add_exercise_details_upper_body.sql
+++ b/internal/database/seeds/20250427022534_add_exercise_details_upper_body.sql
@@ -1,0 +1,43 @@
+-- file: internal/database/seeds/20250427022316_add_upper_body_exercise_details.sql
+-- +goose Up
+-- +goose StatementBegin
+INSERT INTO ExerciseDetails (
+  exercise_id,
+  week_start,
+  week_end,
+  warmup_sets,
+  working_sets,
+  reps,
+  load,
+  rpe,
+  rest_time
+) VALUES
+  -- 2-Grip Pullup
+  (9, 5, 8, 1, 2, '8-10', '63kgx10', '9-10', '~3 MINS'),
+  -- Weighted Dip (Heavy)
+  (10, 5, 8, 2, 1, '6-8', '72kg x 6', '8-9', '~3 MINS'),
+  -- Weighted Dip (Back off)
+  (11, 5, 8, 0, 1, '10-12', '59kg x 10', '9-10', '~3 MINS'),
+  -- Incline Chest-Supported DB Row
+  (12, 5, 8, 1, 2, '8-10', '59kgx10', '9-10', '~2 MINS'),
+  -- Standing DB Arnold Press
+  (13, 5, 8, 1, 2, '8-10', '50kgx10', '9-10', '~2 MINS'),
+  -- A1: DB Incline Curl
+  (14, 5, 8, 1, 2, '15-20', '12.5kgx15', '10', '0 MINS'),
+  -- A2: DB French Press
+  (15, 5, 8, 1, 2, '15-20', NULL, '10', '~1.5 MINS');
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DELETE FROM ExerciseDetails
+WHERE (exercise_id, week_start, week_end) IN (
+  (9, 5, 8),
+  (10, 5, 8),
+  (11, 5, 8),
+  (12, 5, 8),
+  (13, 5, 8),
+  (14, 5, 8),
+  (15, 5, 8)
+);
+-- +goose StatementEnd

--- a/internal/database/seeds/20250427022534_add_exercise_details_upper_body.sql
+++ b/internal/database/seeds/20250427022534_add_exercise_details_upper_body.sql
@@ -1,4 +1,4 @@
--- file: internal/database/seeds/20250427022316_add_upper_body_exercise_details.sql
+-- file: internal/database/seeds/20250427022534_add_exercise_details_upper_body.sql
 -- +goose Up
 -- +goose StatementBegin
 INSERT INTO ExerciseDetails (
@@ -13,17 +13,17 @@ INSERT INTO ExerciseDetails (
   rest_time
 ) VALUES
   -- 2-Grip Pullup
-  (9, 5, 8, 1, 2, '8-10', '63kgx10', '9-10', '~3 MINS'),
+  (9, 5, 8, 1, 2, '8-10', NULL, '9-10', '~3 MINS'),
   -- Weighted Dip (Heavy)
-  (10, 5, 8, 2, 1, '6-8', '72kg x 6', '8-9', '~3 MINS'),
+  (10, 5, 8, 2, 1, '6-8', NULL, '8-9', '~3 MINS'),
   -- Weighted Dip (Back off)
-  (11, 5, 8, 0, 1, '10-12', '59kg x 10', '9-10', '~3 MINS'),
+  (11, 5, 8, 0, 1, '10-12', NULL, '9-10', '~3 MINS'),
   -- Incline Chest-Supported DB Row
-  (12, 5, 8, 1, 2, '8-10', '59kgx10', '9-10', '~2 MINS'),
+  (12, 5, 8, 1, 2, '8-10', NULL, '9-10', '~2 MINS'),
   -- Standing DB Arnold Press
-  (13, 5, 8, 1, 2, '8-10', '50kgx10', '9-10', '~2 MINS'),
+  (13, 5, 8, 1, 2, '8-10', NULL, '9-10', '~2 MINS'),
   -- A1: DB Incline Curl
-  (14, 5, 8, 1, 2, '15-20', '12.5kgx15', '10', '0 MINS'),
+  (14, 5, 8, 1, 2, '15-20', NULL, '10', '0 MINS'),
   -- A2: DB French Press
   (15, 5, 8, 1, 2, '15-20', NULL, '10', '~1.5 MINS');
 -- +goose StatementEnd


### PR DESCRIPTION
This pull request introduces a new `seed-reset` task in the `Makefile`, adds new seed files for database initialization, and removes redundant sequence reset operations from existing seed files. These changes aim to streamline the database seeding process and expand the seed data with upper-body exercises and their details.

### Database Seeding Enhancements:

* **New `seed-reset` Task in `Makefile`:** Added a task to reset the database by wiping out data, resetting sequences, and re-seeding from scratch. This simplifies the process of resetting the database to a clean state during development. (`Makefile`, [MakefileR76-R89](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R76-R89))

* **New Seed Files for Upper Body Data:**
  - Added `20250427022315_add_upper_body_exercise.sql` to seed upper-body exercises, including details like names, notes, and substitutions. (`internal/database/seeds/20250427022315_add_upper_body_exercise.sql`, [internal/database/seeds/20250427022315_add_upper_body_exercise.sqlR1-R33](diffhunk://#diff-3071d07ad08ec1a57352a12000e5da440b1e038f7beae3f9123de896483c0d15R1-R33))
  - Added `20250427022534_add_exercise_details_upper_body.sql` to seed detailed configurations for the newly added upper-body exercises. (`internal/database/seeds/20250427022534_add_exercise_details_upper_body.sql`, [internal/database/seeds/20250427022534_add_exercise_details_upper_body.sqlR1-R43](diffhunk://#diff-4767c4279a7724540b33472ff4db91b223feee8b129801adbda45b81f98c0c4eR1-R43))

### Code Simplification:

* **Removed Redundant Sequence Resets:** Removed sequence reset statements (e.g., `ALTER SEQUENCE ... RESTART WITH 1`) from existing seed files (`20250426132152_init_seed.sql`, `20250426232830_add_exercises_full_body.sql`, `20250427001212_add_exercise_details.sql`) to avoid unnecessary operations during seeding. [[1]](diffhunk://#diff-84088698e29ff0eccb89fabf33c9ee950fe71c388b29c81ff86847aae18bce0aL17-L19) [[2]](diffhunk://#diff-c69d212c3bc67145bfd3c6f0e096d0a367c4477f7a712a9acb990adf2917a5f7L86-L89) [[3]](diffhunk://#diff-5701e75f2d0aea5952d10a592aea4d8ec30649d759c9487e39dcf6ca514eeadeL30-L32)