### PR TITLE
feat: add lower body exercises and their details to the database seed…

### DIFF
--- a/internal/database/seeds/20250428014215_add_lower_body_exercises.sql
+++ b/internal/database/seeds/20250428014215_add_lower_body_exercises.sql
@@ -1,0 +1,62 @@
+-- file: internal/database/seeds/20250428014215_add_lower_body_exercises.sql
+-- +goose Up
+-- +goose StatementBegin
+INSERT INTO
+  Exercises (
+    name,
+    workoutsection_id,
+    notes,
+    substitution_1,
+    substitution_2
+  )
+VALUES
+  (
+    'DB Bulgarian Split Squat',
+    3,
+    'Start with your weaker leg. Squat deep',
+    'Goblet Squat',
+    'Leg Press Toe Press'
+  ),
+  (
+    'DB Romanian Deadlift',
+    3,
+    'Emphasize the stretch in your hamstrings, prevent your lower back from rounding',
+    'Romanian Deadlift',
+    '45 deg Hyperextension'
+  ),
+  (
+    'Goblet Squat',
+    3,
+    'Hold the dumbbell underneath your chin, sit back and down, push your knees out laterally',
+    'Leg Extension',
+    'Step Up'
+  ),
+  (
+    'Leg Press Toe Press',
+    3,
+    'Press all the way up to your toes, stretch your calves at the bottom, don''t bounce.',
+    'Standing Calf Raise',
+    'Seated Calf Raise'
+  ),
+  (
+    'Machine Crunch',
+    3,
+    'Squeeze your abs to move the weight, don''t use your arms to help',
+    'Plate-Weighted Crunch',
+    'Cable Crunch'
+  );
+
+-- +goose StatementEnd
+-- +goose Down
+-- +goose StatementBegin
+DELETE FROM Exercises
+WHERE
+  name IN (
+    'DB Bulgarian Split Squat',
+    'DB Romanian Deadlift',
+    'Goblet Squat',
+    'Leg Press Toe Press',
+    'Machine Crunch'
+  );
+
+-- +goose StatementEnd

--- a/internal/database/seeds/20250428015828_add_lower_body_exercise_details.sql
+++ b/internal/database/seeds/20250428015828_add_lower_body_exercise_details.sql
@@ -1,0 +1,37 @@
+-- file: internal/database/seeds/20250428015828_add_lower_body_exercise_details.sql
+-- +goose Up
+-- +goose StatementBegin
+INSERT INTO ExerciseDetails (
+  exercise_id,
+  week_start,
+  week_end,
+  warmup_sets,
+  working_sets,
+  reps,
+  load,
+  rpe,
+  rest_time
+) VALUES
+  -- DB Bulgarian Split Squat
+  (16, 5, 8, 2, 3, '10-12', NULL, '8-9',  '~2 MINS'),
+  -- DB Romanian Deadlift
+  (17, 5, 8, 2, 2, '10-12', NULL, '8-9',  '~2 MINS'),
+  -- Goblet Squat
+  (18, 5, 8, 1, 1, '12-15', NULL, '9-10', '~1.5 MINS'),
+  -- A1: Leg Press Toe Press
+  (19, 5, 8, 1, 2, '15-20', NULL, '10',   '0 MINS'),
+  -- A2: Machine Crunch
+  (20, 5, 8, 1, 2, '10-12', NULL, '1-9',  '~1.5 MINS');
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DELETE FROM ExerciseDetails
+WHERE (exercise_id, week_start, week_end) IN (
+  (16, 5, 8),
+  (17, 5, 8),
+  (18, 5, 8),
+  (19, 5, 8),
+  (20, 5, 8)
+);
+-- +goose StatementEnd


### PR DESCRIPTION
… files

This pull request introduces two new SQL seed files to add lower body exercises and their corresponding details to the database. The changes include inserting new exercises into the `Exercises` table and their associated details into the `ExerciseDetails` table, along with rollback scripts for both.

### Additions to the `Exercises` table:
* Added five new lower body exercises, including `DB Bulgarian Split Squat`, `DB Romanian Deadlift`, `Goblet Squat`, `Leg Press Toe Press`, and `Machine Crunch`, with notes and substitution options.

### Additions to the `ExerciseDetails` table:
* Added detailed configurations for the five new exercises, specifying parameters such as warmup sets, working sets, reps, and rest times for weeks 5 to 8.