### PR TITLE
Feat/fix route upper lower workout

### DIFF
--- a/internal/controllers/workout_controller.go
+++ b/internal/controllers/workout_controller.go
@@ -1,3 +1,5 @@
+// internal/controllers/workout_controller.go
+
 package controllers
 
 import (
@@ -80,23 +82,18 @@ func GetWorkoutSectionsWithExercises(w http.ResponseWriter, r *http.Request) {
 	}
 
 	query := fmt.Sprintf(`
-			SELECT
-				ws.id AS section_id,
-				ws.name AS section_name,
-				ws.route AS section_route,
-				e.id AS exercise_id,
-				e.name AS exercise_name
-			FROM
-				WorkoutSections ws
-			LEFT JOIN
-				Exercises e
-			ON
-				ws.id = e.workout_section_id
-			WHERE
-				ws.id IN (%s)
-			ORDER BY
-				ws.id, e.id;
-    `, placeholders)
+		SELECT
+			ws.id              AS section_id,
+			ws.name            AS section_name,
+			ws.route           AS section_route,
+			COALESCE(e.id, 0)    AS exercise_id,
+			COALESCE(e.name, '') AS exercise_name
+		FROM WorkoutSections ws
+		LEFT JOIN Exercises e
+			ON ws.id = e.workout_section_id
+		WHERE ws.id IN (%s)
+		ORDER BY ws.id, e.id;
+`, placeholders)
 
 	stmt, err := database.DB.Prepare(query)
 	if err != nil {

--- a/internal/database/seeds/20250426232830_add_exercises_full_body.sql
+++ b/internal/database/seeds/20250426232830_add_exercises_full_body.sql
@@ -4,7 +4,7 @@
 INSERT INTO
   Exercises (
     name,
-    workoutsection_id,
+    workout_section_id,
     notes,
     substitution_1,
     substitution_2

--- a/internal/database/seeds/20250427022315_add_upper_body_exercise.sql
+++ b/internal/database/seeds/20250427022315_add_upper_body_exercise.sql
@@ -3,7 +3,7 @@
 -- +goose StatementBegin
 
 -- Insert Exercises (Upper Body)
-INSERT INTO Exercises (name, workoutsection_id, notes, substitution_1, substitution_2) VALUES
+INSERT INTO Exercises (name, workout_section_id, notes, substitution_1, substitution_2) VALUES
 ('2-Grip Pullup', 2, 'First set 1.5x shoulder width grip. Second set 1.0x shoulder width grip.', 'Machine Pulldown', '2-Grip Lat Pulldown'),
 ('Weighted Dip(Heavy)', 2, 'Tuck your elbows at 45°, lean your torso forward 15°, shoulder width or slightly wider grip.', 'Machine Chest Press', 'Flat DB Press'),
 ('Weighted Dip(Back off)', 2, 'Tuck your elbows at 45°, lean your torso forward 15°, shoulder width or slightly wider grip.', 'Machine Chest Press', 'Flat DB Press'),

--- a/internal/database/seeds/20250428014215_add_lower_body_exercises.sql
+++ b/internal/database/seeds/20250428014215_add_lower_body_exercises.sql
@@ -4,7 +4,7 @@
 INSERT INTO
   Exercises (
     name,
-    workoutsection_id,
+    workout_section_id,
     notes,
     substitution_1,
     substitution_2

--- a/internal/database/statements.go
+++ b/internal/database/statements.go
@@ -1,3 +1,4 @@
+// internal/database/statements.go
 package database
 
 import (
@@ -24,7 +25,11 @@ func PrepareStatements() {
 	}
 
 	StmtGetExercisesBySectionID, err = DB.Prepare(`
-    SELECT e.name, ed.reps, ed.working_sets, ed.load
+    SELECT
+      e.name,
+      ed.reps,
+      ed.working_sets,
+      COALESCE(ed.load, 0) AS load
     FROM Exercises e
     JOIN ExerciseDetails ed ON e.id = ed.exercise_id
     WHERE e.workout_section_id = $1
@@ -34,10 +39,18 @@ func PrepareStatements() {
 	}
 
 	StmtGetExerciseDetails, err = DB.Prepare(`
-  SELECT e.id, e.name, ed.warmup_sets, ed.working_sets, ed.reps, ed.load, ed.rpe, ed.rest_time
-  FROM Exercises e
-  JOIN ExerciseDetails ed ON e.id = ed.exercise_id
-  WHERE e.workout_section_id = $1
+		SELECT
+			e.id,
+			e.name,
+			ed.warmup_sets,
+			ed.working_sets,
+			ed.reps,
+			COALESCE(ed.load, 0) AS load,
+			ed.rpe,
+			ed.rest_time
+		FROM Exercises e
+		JOIN ExerciseDetails ed ON e.id = ed.exercise_id
+		WHERE e.workout_section_id = $1
   `)
 	if err != nil {
 		utils.Logger.Fatal("Failed to prepare StmtGetExerciseDetails", zap.Error(err))


### PR DESCRIPTION
This pull request introduces several changes to improve data handling in the workout application, focusing on SQL query updates, schema consistency, and code organization. The most significant updates include the use of `COALESCE` to handle null values in SQL queries, consistent naming of database fields, and minor structural adjustments to improve readability and maintainability.

### SQL Query Improvements:
* Updated the `GetWorkoutSectionsWithExercises` query in `internal/controllers/workout_controller.go` to use `COALESCE` for handling null values in `exercise_id` and `exercise_name`, ensuring default values are returned when no match is found.
* Modified the `PrepareStatements` function in `internal/database/statements.go` to use `COALESCE` for the `load` field in both the `StmtGetExercisesBySectionID` and `StmtGetExerciseDetails` queries, ensuring null values are replaced with a default value of `0`. [[1]](diffhunk://#diff-46bc8e0cd11e4ee2517d930bceca950db1702e468e2dbc71fd8f9214d22504b9L27-R32) [[2]](diffhunk://#diff-46bc8e0cd11e4ee2517d930bceca950db1702e468e2dbc71fd8f9214d22504b9L37-R50)

### Database Schema Consistency:
* Corrected the column name `workoutsection_id` to `workout_section_id` in multiple seed files (`add_exercises_full_body.sql`, `add_upper_body_exercise.sql`, and `add_lower_body_exercises.sql`) to maintain consistency with the database schema. [[1]](diffhunk://#diff-c69d212c3bc67145bfd3c6f0e096d0a367c4477f7a712a9acb990adf2917a5f7L7-R7) [[2]](diffhunk://#diff-3071d07ad08ec1a57352a12000e5da440b1e038f7beae3f9123de896483c0d15L6-R6) [[3]](diffhunk://#diff-eb63281a5d49a8fbf0ff323f08068e452a17df01204768cc00eeb97046f37dfcL7-R7)

### Code Organization:
* Added file headers to `internal/controllers/workout_controller.go` and `internal/database/statements.go` to improve code organization and readability. [[1]](diffhunk://#diff-aebea32b57c24f21344acdc186c47c6618e6adae06702be1764f8b69cdd906acR1-R2) [[2]](diffhunk://#diff-46bc8e0cd11e4ee2517d930bceca950db1702e468e2dbc71fd8f9214d22504b9R1)