### PR TITLE
feat: add endpoint for fetching exercises list in workout sections

### DIFF
--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -58,6 +58,8 @@ func RegisterRoutes() {
 
 	//frontend fetch from this to display list of exercises
 	http.Handle("/workout-sections/exercises", secureHandler(middleware.RequireSubscription(controllers.GetWorkoutSectionsWithExercises)))
+	// exercise guide by id
+	http.Handle("/workout-sections/exercises/", secureHandler(middleware.RequireSubscription(controllers.GetExerciseGuide)))
 
 	// User submit exercise details
 	http.Handle("/workout-sections/user-exercise-details", secureHandler(controllers.SubmitUserExerciseDetails))

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -55,6 +55,8 @@ func RegisterRoutes() {
 	http.Handle("/workout-sections", secureHandler(middleware.RequireSubscription(controllers.GetWorkoutSections)))
 	http.Handle("/workout-sections/list", secureHandler(middleware.RequireSubscription(controllers.GetExercisesList)))
 	http.Handle("/workout-sections/details", secureHandler(middleware.RequireSubscription(controllers.GetExerciseDetails)))
+
+	//frontend fetch from this to display list of exercises
 	http.Handle("/workout-sections/exercises", secureHandler(middleware.RequireSubscription(controllers.GetWorkoutSectionsWithExercises)))
 
 	// User submit exercise details


### PR DESCRIPTION
This pull request introduces a new endpoint to fetch exercise guides, enhances the `exercise_controller` with a new DTO for structured responses, and updates the routing configuration to support the new functionality. Below are the most important changes:

### New Endpoint for Exercise Guide

* Added a `GetExerciseGuide` function in `exercise_controller.go` to handle requests to `/workout-sections/exercises/{id}/guide`. This function retrieves exercise details, including substitutions, from the database and returns them in a structured format.

### Data Transfer Object (DTO)

* Introduced a new `ExerciseGuideDTO` struct in `exercise_controller.go` to provide a consistent response format for the exercise guide endpoint. It includes fields for `ID`, `Name`, `Notes`, and `Substitutions`.

### Routing Updates

* Updated the `RegisterRoutes` function in `routes.go` to include a new route for `/workout-sections/exercises/{id}/guide`, enabling frontend access to the exercise guide endpoint.